### PR TITLE
Fix bug in ToChain

### DIFF
--- a/SpinorHelicity4D.wl
+++ b/SpinorHelicity4D.wl
@@ -578,7 +578,7 @@ Chain[$angle,x_,{y___,x_,z___},k_,type2_]/;OddQ[Length[{y}]]:=Chain[$angle,x,{y}
 
 (*Converting emty chains into brackets*)
 Chain[$angle,x_,{},y_,$angle]:=SpinorAngleBracket[x,y];
-Chain[$square,x_,{},y_,$square]:=SpinorAngleBracket[x,y];
+Chain[$square,x_,{},y_,$square]:=SpinorSquareBracket[x,y];
 
 locexp=locexp;
 ];


### PR DESCRIPTION
This fixes a small bug in ToChain[], which sometimes mistakenly converts square brackets into angle brackets, for example:
```
DeclareMom[u];
DeclareMassless[k1, k2];
Chain[$angle, "k1", {"u"}, "k2", $square] Chain[$angle, "k2", {"u"}, "k1", $square] SpinorSquareBracket["k1", "k2"] // ToChain
```
outputs
```
Chain[$square, "k1", {"u", "k2", "u"}, "k1", $angle] SpinorAngleBracket["k1", "k2"]
```
instead of
```
Chain[$square, "k1", {"u", "k2", "u"}, "k1", $angle] SpinorSquareBracket["k1", "k2"]
```
